### PR TITLE
Increase timeout on requests to 5 minutes

### DIFF
--- a/lib/smartcar.rb
+++ b/lib/smartcar.rb
@@ -32,6 +32,8 @@ require "smartcar/user"
   API_VERSION = "v1.0".freeze
   # Host to connect to smartcar
   SITE = "https://api.smartcar.com/".freeze
+  # Seconds to wait for response
+  REQUEST_TIMEOUT = 300
 
   # Path for smartcar oauth
   OAUTH_PATH = "https://connect.smartcar.com/oauth/authorize".freeze

--- a/lib/smartcar/base.rb
+++ b/lib/smartcar/base.rb
@@ -66,7 +66,7 @@ module Smartcar
     #
     # @return [OAuth2::AccessToken] An initialized AccessToken instance that acts as service client
     def service
-      @service ||= Faraday.new(url: SITE)
+      @service ||= Faraday.new(url: SITE, request: {timeout: REQUEST_TIMEOUT})
     end
   end
 end


### PR DESCRIPTION
Per my communications with Victor Black at Smartcar, the timeout for requests should be 5 minutes. I believe Faraday's default timeout is 60 seconds.

Not sure how you want to handle versioning/releasing this but let me know if there's anything else I can do to help out.

Also feel free to close this PR if you have a separate fix coming.