### PR TITLE
feat: update Oauth methods signature

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    smartcar (1.0.8)
+    smartcar (2.0.0)
       oauth2 (~> 1.4)
 
 GEM

--- a/lib/smartcar/utils.rb
+++ b/lib/smartcar/utils.rb
@@ -10,6 +10,15 @@
     end
   end
 
+  # Utility method to return a hash of the isntance variables
+  #
+  # @return [Hash] hash of all instance variables
+  def to_hash
+    instance_variables.each_with_object({}) do |attribute, hash|
+      hash[attribute.to_s.delete("@").to_sym] = instance_variable_get(attribute)
+    end
+  end
+
   # gets a given env variable, checks for existence and throws exception if not present
   # @param config_name [String] key of the env variable
   #

--- a/lib/smartcar/version.rb
+++ b/lib/smartcar/version.rb
@@ -1,4 +1,4 @@
 module Smartcar
   # Gem current version number
-  VERSION = "1.0.8"
+  VERSION = "2.0.0"
 end

--- a/spec/smartcar/e2e/oauth_spec.rb
+++ b/spec/smartcar/e2e/oauth_spec.rb
@@ -15,13 +15,22 @@ RSpec.describe Smartcar::Oauth do
     end
   end
 
-  describe '.refresh_token' do
+  describe '.exchange_refresh_token' do
     it 'should refresh and fetch all the tokens' do
       url = subject.authorization_url
       code = AuthHelper.run_auth_flow(url)
       old_token_hash = subject.get_token(code)
-      new_token_hash = subject.refresh_token(old_token_hash)
+      new_token_hash = subject.exchange_refresh_token(old_token_hash[:refresh_token])
       expect(new_token_hash.keys.map(&:to_s)).to match_array(%w[token_type access_token refresh_token expires_at])
+    end
+  end
+
+  context 'expired?' do
+    it 'should return boolean indicating if token is expired using expires_at' do
+      expiredTime = (Time.now - (60*60*24)).to_i
+      validTime = (Time.now + (60*60*24)).to_i
+      expect(subject.expired?(expiredTime)).to be_truthy
+      expect(subject.expired?(validTime)).to be_falsey
     end
   end
 end

--- a/spec/smartcar/unit/oauth_spec.rb
+++ b/spec/smartcar/unit/oauth_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe Smartcar::Oauth do
     client_secret: "client_secret",
     test_mode: true,
     scope: ["testing"],
-    flags: ["country:DE"],
-    state: 'blah',
   }) }
   let(:obj) { double("dummy object for client") }
 
@@ -18,14 +16,24 @@ RSpec.describe Smartcar::Oauth do
     it 'should call authorize_url from client.authcode' do
       expect(obj).to receive(:authorize_url).with({
         redirect_uri: "test_url",
+        scope: "testing",
         approval_prompt: Smartcar::AUTO,
         mode: Smartcar::TEST,
         response_type: Smartcar::CODE,
-        scope: "testing",
         flags: "country:DE",
         state: 'blah',
+        make: 'blah',
+        single_select: true,
+        single_select_vin: 'vin',
       }).and_return("result")
-      expect(subject.authorization_url).to eq "result"
+      expect(subject.authorization_url(
+        {
+          flags: ["country:DE"],
+          state: 'blah',
+          make: 'blah',
+          single_select: {vin: 'vin'},
+        }
+      )).to eq "result"
     end
   end
 
@@ -36,15 +44,15 @@ RSpec.describe Smartcar::Oauth do
     end
   end
 
-  context 'refresh_token' do
+  context 'exchange_refresh_token' do
     it 'should create new OAuth2::AccessToken object, refresh and return new hash' do
-      token_hash = {token: "token"}
+      token_hash = {refresh_token: "refresh_token"}
       double_object = double("obj")
       allow(subject).to receive_message_chain(:client).and_return(obj)
       expect(OAuth2::AccessToken).to receive(:from_hash).with(obj,token_hash).and_return(double_object)
       expect(double_object).to receive(:refresh!).and_return(double_object)
       expect(double_object).to receive(:to_hash)
-      subject.refresh_token(token_hash)
+      subject.exchange_refresh_token(token_hash[:refresh_token])
     end
   end
 


### PR DESCRIPTION
Breaking changes information: 
-  `Smartcar::Oauth#initialize` (Constructor) - No longer takes in some of the optional parameters from before. All of those parameters were more related to building the authorization url so they have been moved there. The only parameters it can take right now are `client_id, client_secret, redirect_uri, scope, test_mode` .
- ` Smartcar::Oauth#authorize_url` - All the remaining parameters other than ones mentioned above are now accepted here. Additionally `single_select, single_select_vin` support has been added which was missing before.
- `Smartcar::Oauth#refresh_token` - The method name previously was `refresh_token` , it has been changed to `exchange_refresh_token` to be more verbose and the signature has been simplified to accept just a `refresh_token` string instead of the whole `token_hash`.

Other features introduced
- `Smartcar::Oauth#expired?` - This is a new method added which takes in a `expires_at` in time since epoch and returns boolean indicated if the token is valid. Even though it is internally using `OAuth2::AccessToken` methods, but at the end of the day this just compares the time with `Time.now` ([source](https://github.com/oauth-xx/oauth2/blob/master/lib/oauth2/access_token.rb#L78)) 
- `to_hash`- This is a utility instance method added to all the data classes (`Smartcar::<data item like Location, Fuel etc>`). We can now call `to_hash` on any of those objects to get a hash of all the attributes. Ex : 
```
pp vehicle.fuel.to_hash
=> {:range=>233.7,
 :percentRemaining=>0.28,
 :amountRemaining=>43.24,
 :meta=>
  {"date"=>"Wed, 04 Nov 2020 18:12:31 GMT",
   "content-type"=>"application/json; charset=utf-8",
   "content-length"=>"63",
   "connection"=>"keep-alive",
   "access-control-allow-origin"=>"*",
   "strict-transport-security"=>
    "max-age=63072000; includeSubDomains;\n" + "     preload",
   "sc-data-age"=>"2020-11-04T18:12:31.588Z",
   "sc-unit-system"=>"imperial",
   "sc-request-id"=>"0161a94f-212b-40e0-a45c-995627f82b2b"}}
```
