### PR TITLE
Fixed Vehicle#disconnect!

### DIFF
--- a/lib/smartcar/base.rb
+++ b/lib/smartcar/base.rb
@@ -26,7 +26,7 @@ module Smartcar
       define_method verb do |path, data=nil|
         response = service.send(verb) do |request|
           request.headers['Authorization'] = "BEARER #{token}"
-          request.headers['Authorization'] = "BASIC #{get_basic_auth}" if data[:auth] == BASIC
+          request.headers['Authorization'] = "BASIC #{get_basic_auth}" if data && data[:auth] == BASIC
           request.headers['sc-unit-system'] = unit_system if unit_system
           request.headers['Content-Type'] = "application/json"
           complete_path = "/v#{version}#{path}"

--- a/lib/smartcar/vehicle.rb
+++ b/lib/smartcar/vehicle.rb
@@ -92,7 +92,7 @@ module Smartcar
     # @return [Boolean] true if success
     def disconnect!
       response = delete(PATH.call(id) + "/application")
-      response['status'] == SUCCESS
+      response[0]['status'] == SUCCESS
     end
 
     # Methods Used to lock car

--- a/spec/smartcar/unit/vehicle_spec.rb
+++ b/spec/smartcar/unit/vehicle_spec.rb
@@ -1,0 +1,66 @@
+RSpec.describe Smartcar::Vehicle do
+  let(:id) { 'abc-123-def-456' }
+  let(:vehicle) { Smartcar::Vehicle.new(token: "fake-token", id: id) }
+  let(:stubs) { Faraday::Adapter::Test::Stubs.new }
+  let(:mock_service) { Faraday.new {|conn| conn.adapter :test, stubs} }
+
+  before do
+    allow(vehicle).to receive(:service).and_return(mock_service)
+  end
+
+  describe 'vehicle_attributes' do
+    before do
+      stubs.get("/v1.0/vehicles/#{id}") do |env|
+        # [HTTP status, Response headers, Response body]
+        [
+          200,
+          {'Content-Type': 'application/json'},
+          {
+            'id': id,
+            'make': 'TESLA',
+            'model': 'Model S',
+            'year': 2014
+          }.to_json
+        ]
+      end
+    end
+
+    it 'returns a VehicleAttributes object' do
+      result = vehicle.vehicle_attributes
+
+      expect(result).to be_a(Smartcar::VehicleAttributes)
+      expect(result.id).to eq(id)
+      expect(result.make).to eq('TESLA')
+      expect(result.model).to eq('Model S')
+      expect(result.year).to eq(2014)
+    end
+  end
+
+  describe 'vin' do
+    let(:vin) { '1234A67Q90F2T4567' }
+
+    before do
+      stubs.get("/v1.0/vehicles/#{id}/vin") do |env|
+        # [HTTP status, Response headers, Response body]
+        [200, {'Content-Type': 'application/json'}, {'vin': vin}.to_json]
+      end
+    end
+
+    it 'returns the vin' do
+      expect(vehicle.vin).to eq(vin)
+    end
+  end
+
+  describe 'disconnect!' do
+    before do
+      stubs.delete("/v1.0/vehicles/#{id}/application") do |env|
+        # [HTTP status, Response headers, Response body]
+        [200, {'Content-Type': 'application/json'}, {'status': 'success'}.to_json]
+      end
+    end
+
+    it 'disconnects the vehicle' do
+      expect(vehicle.disconnect!).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
The `Vehicle#disconnect!` method has been broken for a while, calling it results in the following exception:
```
     NoMethodError:
       undefined method `[]' for nil:NilClass
     # ./lib/smartcar/base.rb:29:in `block (3 levels) in <class:Base>'
```

The fix itself is relatively simple, but I noticed the behavior isn't tested at all and I also couldn't get the E2E specs to run locally (Selenium couldn't find the appropriate elements in the auth flow). I decided to add a more "integration" style of spec that stubs the Faraday connection so it can be tested without making actual requests to the API.

I added specs for `vehicle_attributes`, `vin`, and `disconnect!`. I know this isn't exhaustive coverage of the behavior in Vehicle, but I primarily wanted to establish the pattern and then fix `disconnect!`.