### PR TITLE
feat(vehicle): add general purpose request method to Vehicle

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,6 @@ Metrics/MethodLength:
   Max: 20
   Exclude:
     - 'spec/smartcar/helpers/auth_helper.rb'
+
+Metrics/ClassLength:
+  Max: 200

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    smartcar (3.0.5)
+    smartcar (3.1.0)
       oauth2 (~> 1.4)
       recursive-open-struct (~> 1.1.3)
 

--- a/lib/smartcar/base.rb
+++ b/lib/smartcar/base.rb
@@ -2,6 +2,7 @@
 
 require 'oauth2'
 require 'base64'
+require 'rbconfig'
 module Smartcar
   # The Base class for all of the other class.
   # Let other classes inherit from here and put common methods here.
@@ -29,6 +30,8 @@ module Smartcar
           request_headers['Authorization'] = auth_type == BASIC ? "Basic #{token}" : "Bearer #{token}"
           request_headers['sc-unit-system'] = unit_system if unit_system
           request_headers['Content-Type'] = 'application/json'
+          request_headers['User-Agent'] =
+            "Smartcar/#{version} (#{RbConfig::CONFIG['host_os']}; #{RbConfig::CONFIG['arch']}) Ruby v#{RUBY_VERSION}"
           request.headers = request_headers.merge(headers)
           complete_path = "/v#{version}#{path}"
           if verb == :get

--- a/lib/smartcar/base.rb
+++ b/lib/smartcar/base.rb
@@ -23,11 +23,13 @@ module Smartcar
       # @param data [Hash] request body if needed.
       #
       # @return [Hash] The response Json parsed as a hash.
-      define_method verb do |path, data = nil|
+      define_method verb do |path, data = nil, headers = {}|
         response = service.send(verb) do |request|
-          request.headers['Authorization'] = auth_type == BASIC ? "Basic #{token}" : "Bearer #{token}"
-          request.headers['sc-unit-system'] = unit_system if unit_system
-          request.headers['Content-Type'] = 'application/json'
+          request_headers = {}
+          request_headers['Authorization'] = auth_type == BASIC ? "Basic #{token}" : "Bearer #{token}"
+          request_headers['sc-unit-system'] = unit_system if unit_system
+          request_headers['Content-Type'] = 'application/json'
+          request.headers = request_headers.merge(headers)
           complete_path = "/v#{version}#{path}"
           if verb == :get
             request.url complete_path, data

--- a/lib/smartcar/base.rb
+++ b/lib/smartcar/base.rb
@@ -31,7 +31,7 @@ module Smartcar
           request_headers['sc-unit-system'] = unit_system if unit_system
           request_headers['Content-Type'] = 'application/json'
           request_headers['User-Agent'] =
-            "Smartcar/#{version} (#{RbConfig::CONFIG['host_os']}; #{RbConfig::CONFIG['arch']}) Ruby v#{RUBY_VERSION}"
+            "Smartcar/#{VERSION} (#{RbConfig::CONFIG['host_os']}; #{RbConfig::CONFIG['arch']}) Ruby v#{RUBY_VERSION}"
           request.headers = request_headers.merge(headers)
           complete_path = "/v#{version}#{path}"
           if verb == :get

--- a/lib/smartcar/vehicle.rb
+++ b/lib/smartcar/vehicle.rb
@@ -201,7 +201,7 @@ module Smartcar
     #
     # @param webhook_id [String] Webhook id to subscribe to
     #
-    # @return [OpenStruct] And object representing the JSON response and a meta attribute
+    # @return [OpenStruct] An object representing the JSON response and a meta attribute
     #   with the relevant items from response headers.
     def subscribe!(webhook_id)
       response, headers = post(METHODS.dig(:subscribe!, :path).call(id, webhook_id), {})
@@ -233,6 +233,22 @@ module Smartcar
       request_body = { requests: paths.map { |path| { path: path } } }
       response, headers = post("/vehicles/#{id}/batch", request_body)
       process_batch_response(response, headers)
+    end
+
+    # General purpose method to make requests to the Smartcar API.
+    # API - https://smartcar.com/docs/api#request
+    # @param method [String] The HTTP request method to use.
+    # @param path [String] The path to make the request to.
+    # @param body [Hash] The request body.
+    # @param headers [Hash] The headers to inlcude in the request.
+    #
+    # @return [OpenStruct] An object representing the JSON response and a meta attribute
+    #   with the relevant items from response headers.
+    
+    def request(method, path, body = {}, headers = {})
+      path = "/vehicles/#{id}/#{path}"
+      response, headers = send(method, path, body, headers)
+      build_response(response, headers)
     end
   end
 end

--- a/lib/smartcar/vehicle.rb
+++ b/lib/smartcar/vehicle.rb
@@ -236,22 +236,19 @@ module Smartcar
     end
 
     # General purpose method to make requests to the Smartcar API.
-    # API - https://smartcar.com/docs/api#request
+    #
     # @param method [String] The HTTP request method to use.
     # @param path [String] The path to make the request to.
     # @param body [Hash] The request body.
     # @param headers [Hash] The headers to inlcude in the request.
     #
-    # @return [OpenStruct] An object representing the JSON response and a meta attribute
-    #   with the relevant items from response headers.
-    
+    # @return [OpenStruct] An object with a "body" attribute that contains the
+    #   response body and a "meta" attribute with the relevant items from response headers.
     def request(method, path, body = {}, headers = {})
       path = "/vehicles/#{id}/#{path}"
       raw_response, headers = send(method, path, body, headers)
       meta = build_meta(headers)
-      response = {}
-      response = json_to_ostruct({body: raw_response, meta: meta})
-      response
+      json_to_ostruct({ body: raw_response, meta: meta })
     end
   end
 end

--- a/lib/smartcar/vehicle.rb
+++ b/lib/smartcar/vehicle.rb
@@ -235,7 +235,8 @@ module Smartcar
       process_batch_response(response, headers)
     end
 
-    # General purpose method to make requests to the Smartcar API.
+    # General purpose method to make requests to the Smartcar API - can be
+    # used to make requests to brand specific endpoints.
     #
     # @param method [String] The HTTP request method to use.
     # @param path [String] The path to make the request to.

--- a/lib/smartcar/vehicle.rb
+++ b/lib/smartcar/vehicle.rb
@@ -247,8 +247,11 @@ module Smartcar
     
     def request(method, path, body = {}, headers = {})
       path = "/vehicles/#{id}/#{path}"
-      response, headers = send(method, path, body, headers)
-      build_response(response, headers)
+      raw_response, headers = send(method, path, body, headers)
+      meta = build_meta(headers)
+      response = {}
+      response = json_to_ostruct({body: raw_response, meta: meta})
+      response
     end
   end
 end

--- a/lib/smartcar/version.rb
+++ b/lib/smartcar/version.rb
@@ -2,5 +2,5 @@
 
 module Smartcar
   # Gem current version number
-  VERSION = '3.0.5'
+  VERSION = '3.1.0'
 end

--- a/spec/smartcar/e2e/vehicle_spec.rb
+++ b/spec/smartcar/e2e/vehicle_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Smartcar::Vehicle do
     describe '#odometer' do
       it 'should return an odometer object' do
         result = @vehicle.odometer
-        expect(result.distance.instance_of?(Float)).to eq(true)
+        expect(result.distance).to be_a Float
         expect(result.meta.request_id.length).to eq(36)
         expect(result.meta.unit_system).to eq('metric')
         expect(result.meta.data_age.is_a?(DateTime)).to eq(true)
@@ -151,7 +151,7 @@ RSpec.describe Smartcar::Vehicle do
     describe '#request - odometer' do
       it 'should use request method to return an odometer object' do
         result = @vehicle.request('get', 'odometer')
-        expect(result.body.distance.instance_of?(Float)).to eq(true)
+        expect(result.body.distance).to be_a Float
         expect(result.meta.request_id.length).to eq(36)
         expect(result.meta.unit_system).to eq('metric')
         expect(result.meta.data_age.is_a?(DateTime)).to eq(true)

--- a/spec/smartcar/e2e/vehicle_spec.rb
+++ b/spec/smartcar/e2e/vehicle_spec.rb
@@ -188,11 +188,11 @@ RSpec.describe Smartcar::Vehicle do
                              Authorization: 'Bearer abc'
                            })
         end.to(raise_error do |error|
-                 expect(error.status_code).to eq(401)
-                 expect(error.type).to eq('AUTHENTICATION')
-                 expect(error.description).to eq(expected_description)
-                 expect(error.doc_url).to eq('https://smartcar.com/docs/errors/v2.0/other-errors/#authentication')
-               end)
+          expect(error.status_code).to eq(401)
+          expect(error.type).to eq('AUTHENTICATION')
+          expect(error.description).to eq(expected_description)
+          expect(error.doc_url).to eq('https://smartcar.com/docs/errors/v2.0/other-errors/#authentication')
+        end)
       end
     end
 

--- a/spec/smartcar/e2e/vehicle_spec.rb
+++ b/spec/smartcar/e2e/vehicle_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Smartcar::Vehicle do
     describe '#request - odometer' do
       it 'should use request method to return an odometer object' do
         result = @vehicle.request("get","odometer")
-        expect(result.distance.instance_of?(Float)).to eq(true)
+        expect(result.body.distance.instance_of?(Float)).to eq(true)
         expect(result.meta.request_id.length).to eq(36)
         expect(result.meta.unit_system).to eq('metric')
         expect(result.meta.data_age.is_a?(DateTime)).to eq(true)
@@ -214,17 +214,17 @@ RSpec.describe Smartcar::Vehicle do
     describe '#request - batch' do
       it 'should return hash of objects with attribute requested as keys' do
         result = @vehicle.request("post", "batch", { requests: [{ path: "/odometer" }, { path: "/tires/pressure" }] })
-        expect(result.responses[0].path).to eq("/odometer")
-        expect(result.responses[0].body.is_a?(OpenStruct)).to eq(true)
-        expect(result.responses[0].headers).not_to be_nil
-        expect(result.responses[0].body.distance).not_to be_nil
-        expect(result.responses[1].path).to eq("/tires/pressure")
-        expect(result.responses[1].body.is_a?(OpenStruct)).to eq(true)
-        expect(result.responses[1].headers).not_to be_nil
-        expect(result.responses[1].body.frontLeft).not_to be_nil
-        expect(result.responses[1].body.frontRight).not_to be_nil
-        expect(result.responses[1].body.backLeft).not_to be_nil
-        expect(result.responses[1].body.backRight).not_to be_nil
+        expect(result.body.responses[0].path).to eq("/odometer")
+        expect(result.body.responses[0].body.is_a?(OpenStruct)).to eq(true)
+        expect(result.body.responses[0].headers).not_to be_nil
+        expect(result.body.responses[0].body.distance).not_to be_nil
+        expect(result.body.responses[1].path).to eq("/tires/pressure")
+        expect(result.body.responses[1].body.is_a?(OpenStruct)).to eq(true)
+        expect(result.body.responses[1].headers).not_to be_nil
+        expect(result.body.responses[1].body.frontLeft).not_to be_nil
+        expect(result.body.responses[1].body.frontRight).not_to be_nil
+        expect(result.body.responses[1].body.backLeft).not_to be_nil
+        expect(result.body.responses[1].body.backRight).not_to be_nil
       end
     end
 

--- a/spec/smartcar/e2e/vehicle_spec.rb
+++ b/spec/smartcar/e2e/vehicle_spec.rb
@@ -158,6 +158,23 @@ RSpec.describe Smartcar::Vehicle do
       end
     end
 
+    describe '#request - batch' do
+      it 'should return hash of objects with attribute requested as keys' do
+        result = @vehicle.request('post', 'batch', { requests: [{ path: '/odometer' }, { path: '/tires/pressure' }] })
+        expect(result.body.responses[0].path).to eq('/odometer')
+        expect(result.body.responses[0].body.is_a?(OpenStruct)).to eq(true)
+        expect(result.body.responses[0].headers).not_to be_nil
+        expect(result.body.responses[0].body.distance).not_to be_nil
+        expect(result.body.responses[1].path).to eq('/tires/pressure')
+        expect(result.body.responses[1].body.is_a?(OpenStruct)).to eq(true)
+        expect(result.body.responses[1].headers).not_to be_nil
+        expect(result.body.responses[1].body.frontLeft).not_to be_nil
+        expect(result.body.responses[1].body.frontRight).not_to be_nil
+        expect(result.body.responses[1].body.backLeft).not_to be_nil
+        expect(result.body.responses[1].body.backRight).not_to be_nil
+      end
+    end
+
     describe '#request - override auth header' do
       it 'should throw error in making request' do
         expected_description = 'The authorization header is missing or malformed, '\
@@ -208,23 +225,6 @@ RSpec.describe Smartcar::Vehicle do
           expect(result.message).to eq('Successfully sent request to vehicle')
           expect(result.meta.request_id.length).to eq(36)
         end
-      end
-    end
-
-    describe '#request - batch' do
-      it 'should return hash of objects with attribute requested as keys' do
-        result = @vehicle.request('post', 'batch', { requests: [{ path: '/odometer' }, { path: '/tires/pressure' }] })
-        expect(result.body.responses[0].path).to eq('/odometer')
-        expect(result.body.responses[0].body.is_a?(OpenStruct)).to eq(true)
-        expect(result.body.responses[0].headers).not_to be_nil
-        expect(result.body.responses[0].body.distance).not_to be_nil
-        expect(result.body.responses[1].path).to eq('/tires/pressure')
-        expect(result.body.responses[1].body.is_a?(OpenStruct)).to eq(true)
-        expect(result.body.responses[1].headers).not_to be_nil
-        expect(result.body.responses[1].body.frontLeft).not_to be_nil
-        expect(result.body.responses[1].body.frontRight).not_to be_nil
-        expect(result.body.responses[1].body.backLeft).not_to be_nil
-        expect(result.body.responses[1].body.backRight).not_to be_nil
       end
     end
 

--- a/spec/smartcar/e2e/vehicle_spec.rb
+++ b/spec/smartcar/e2e/vehicle_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Smartcar::Vehicle do
 
     describe '#request - odometer' do
       it 'should use request method to return an odometer object' do
-        result = @vehicle.request("get","odometer")
+        result = @vehicle.request('get', 'odometer')
         expect(result.body.distance.instance_of?(Float)).to eq(true)
         expect(result.meta.request_id.length).to eq(36)
         expect(result.meta.unit_system).to eq('metric')
@@ -161,22 +161,21 @@ RSpec.describe Smartcar::Vehicle do
     describe '#request - override auth header' do
       it 'should throw error in making request' do
         expected_description = 'The authorization header is missing or malformed, '\
-        'or it contains invalid or expired authentication credentials. Please ' \
-        'check for missing parameters, spelling and casing mistakes, and ' \
-        'other syntax issues.'
+                               'or it contains invalid or expired authentication credentials. Please ' \
+                               'check for missing parameters, spelling and casing mistakes, and ' \
+                               'other syntax issues.'
 
-        expect { 
-          @vehicle.request("get","odometer", {}, {
-              'sc-unit-system': 'imperial',
-              Authorization: 'Bearer abc',
-            }
-          )
-         }.to(raise_error do |error|
-          expect(error.status_code).to eq(401)
-          expect(error.type).to eq('AUTHENTICATION')
-          expect(error.description).to eq(expected_description)
-          expect(error.doc_url).to eq('https://smartcar.com/docs/errors/v2.0/other-errors/#authentication')
-        end)
+        expect do
+          @vehicle.request('get', 'odometer', {}, {
+                             'sc-unit-system': 'imperial',
+                             Authorization: 'Bearer abc'
+                           })
+        end.to(raise_error do |error|
+                 expect(error.status_code).to eq(401)
+                 expect(error.type).to eq('AUTHENTICATION')
+                 expect(error.description).to eq(expected_description)
+                 expect(error.doc_url).to eq('https://smartcar.com/docs/errors/v2.0/other-errors/#authentication')
+               end)
       end
     end
 
@@ -194,7 +193,7 @@ RSpec.describe Smartcar::Vehicle do
     before(:context) do
       @token = AuthHelper.run_auth_flow_and_get_tokens(
         nil,
-        'CHEVROLET',
+        'CHEVROLET'
       )[:access_token]
       @vehicle_ids = Smartcar.get_vehicles(token: @token).vehicles
       @vehicle = Smartcar::Vehicle.new(token: @token, id: @vehicle_ids.first)
@@ -213,12 +212,12 @@ RSpec.describe Smartcar::Vehicle do
 
     describe '#request - batch' do
       it 'should return hash of objects with attribute requested as keys' do
-        result = @vehicle.request("post", "batch", { requests: [{ path: "/odometer" }, { path: "/tires/pressure" }] })
-        expect(result.body.responses[0].path).to eq("/odometer")
+        result = @vehicle.request('post', 'batch', { requests: [{ path: '/odometer' }, { path: '/tires/pressure' }] })
+        expect(result.body.responses[0].path).to eq('/odometer')
         expect(result.body.responses[0].body.is_a?(OpenStruct)).to eq(true)
         expect(result.body.responses[0].headers).not_to be_nil
         expect(result.body.responses[0].body.distance).not_to be_nil
-        expect(result.body.responses[1].path).to eq("/tires/pressure")
+        expect(result.body.responses[1].path).to eq('/tires/pressure')
         expect(result.body.responses[1].body.is_a?(OpenStruct)).to eq(true)
         expect(result.body.responses[1].headers).not_to be_nil
         expect(result.body.responses[1].body.frontLeft).not_to be_nil

--- a/spec/smartcar/e2e/vehicle_spec.rb
+++ b/spec/smartcar/e2e/vehicle_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Smartcar::Vehicle do
     describe '#odometer' do
       it 'should return an odometer object' do
         result = @vehicle.odometer
-        expect(result.distance).to be_a Float
+        expect(result.distance.is_a?(Numeric)).to eq(true)
         expect(result.meta.request_id.length).to eq(36)
         expect(result.meta.unit_system).to eq('metric')
         expect(result.meta.data_age.is_a?(DateTime)).to eq(true)
@@ -151,7 +151,7 @@ RSpec.describe Smartcar::Vehicle do
     describe '#request - odometer' do
       it 'should use request method to return an odometer object' do
         result = @vehicle.request('get', 'odometer')
-        expect(result.body.distance).to be_a Float
+        expect(result.body.distance.is_a?(Numeric)).to eq(true)
         expect(result.meta.request_id.length).to eq(36)
         expect(result.meta.unit_system).to eq('metric')
         expect(result.meta.data_age.is_a?(DateTime)).to eq(true)

--- a/spec/smartcar/e2e/vehicle_spec.rb
+++ b/spec/smartcar/e2e/vehicle_spec.rb
@@ -193,7 +193,8 @@ RSpec.describe Smartcar::Vehicle do
     before(:context) do
       @token = AuthHelper.run_auth_flow_and_get_tokens(
         nil,
-        'CHEVROLET'
+        'FORD',
+        ['required:control_charge', 'required:control_security', 'read_charge']
       )[:access_token]
       @vehicle_ids = Smartcar.get_vehicles(token: @token).vehicles
       @vehicle = Smartcar::Vehicle.new(token: @token, id: @vehicle_ids.first)


### PR DESCRIPTION
Add a new general purpose/BSE related method `def request(method, path, body = {}, headers = {})` to Vehicle class that allows for making requests to the Smartcar API. Also, add E2E tests for this new request method.

Test Plan: create an app with my Smartcar Developer account and make requests with this method once it's in staging/prod.

Asana: https://app.asana.com/0/1201332815308984/1201617268953137/f