### PR TITLE
fix: set request() method to lowercase

### DIFF
--- a/lib/smartcar/vehicle.rb
+++ b/lib/smartcar/vehicle.rb
@@ -247,7 +247,7 @@ module Smartcar
     #   response body and a "meta" attribute with the relevant items from response headers.
     def request(method, path, body = {}, headers = {})
       path = "/vehicles/#{id}/#{path.downcase}"
-      raw_response, headers = send(method, path.downcase, body, headers)
+      raw_response, headers = send(method.downcase, path, body, headers)
       meta = build_meta(headers)
       json_to_ostruct({ body: raw_response, meta: meta })
     end

--- a/lib/smartcar/vehicle.rb
+++ b/lib/smartcar/vehicle.rb
@@ -246,7 +246,7 @@ module Smartcar
     # @return [OpenStruct] An object with a "body" attribute that contains the
     #   response body and a "meta" attribute with the relevant items from response headers.
     def request(method, path, body = {}, headers = {})
-      path = "/vehicles/#{id}/#{path.downcase}"
+      path = "/vehicles/#{id}/#{path}"
       raw_response, headers = send(method.downcase, path, body, headers)
       meta = build_meta(headers)
       json_to_ostruct({ body: raw_response, meta: meta })

--- a/lib/smartcar/vehicle.rb
+++ b/lib/smartcar/vehicle.rb
@@ -246,8 +246,8 @@ module Smartcar
     # @return [OpenStruct] An object with a "body" attribute that contains the
     #   response body and a "meta" attribute with the relevant items from response headers.
     def request(method, path, body = {}, headers = {})
-      path = "/vehicles/#{id}/#{path}"
-      raw_response, headers = send(method, path, body, headers)
+      path = "/vehicles/#{id}/#{path.downcase}"
+      raw_response, headers = send(method, path.downcase, body, headers)
       meta = build_meta(headers)
       json_to_ostruct({ body: raw_response, meta: meta })
     end

--- a/spec/smartcar/unit/vehicle_spec.rb
+++ b/spec/smartcar/unit/vehicle_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative '../helpers/auth_helper'
+require_relative '../../spec_helper'
+RSpec.describe Smartcar::Vehicle do
+  subject do
+    Smartcar::Vehicle.new(
+      token: 'token',
+      id: 'vehicle_id'
+    )
+  end
+
+  before do
+    WebMock.disable_net_connect!
+  end
+
+  after do
+    WebMock.allow_net_connect!
+  end
+
+  describe '#request' do
+    context 'successful request with uppercase method' do
+      it 'should make the request when the method name is uppercase' do
+        subject = Smartcar::Vehicle.new(
+          token: 'token',
+          id: 'vehicle_id',
+          options: { unit_system: 'imperial', version: 2.0 }
+        )
+        stub_request(:get, 'https://api.smartcar.com/v2.0/vehicles/vehicle_id/odometer')
+          .with(headers: { 'Authorization' => 'Bearer token', 'sc-unit-system' => 'imperial' })
+          .to_return(
+            {
+              status: 200,
+              body: { pizza: 'pasta' }.to_json
+            }
+          )
+        result = subject.request('GET', 'odometer')
+        expect(result.body.pizza).to eq('pasta')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Always sets request() method argument method to lower case to allow requests like:
vehicle.request("GET", "odometer")

Test Plan: use getting-started-app to test uppercase method names as arguments.