### PR TITLE
Allow users to provide customized Faraday::Connection objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,32 @@ Example Usage for oAuth -
 # get a new token or use .
 ```
 
+## Advanced configuration
+
+This SDK uses the [Faraday HTTP client library](https://lostisland.github.io/faraday/) which supports extensive customization through the use of middleware. If you need to customize the behavior of HTTP request/response processing, you can provide your own instance of Faraday::Connection to most methods in this library.
+
+**Important:** If you provide your own Faraday connection, you are responsible for configuring all HTTP connection behavior, including timeouts! This SDK uses some custom timeouts internally to ensure best behavior by default, so unless you want to customize them you may want to replicate those timeouts.
+
+Example of providing a custom Faraday connection to various methods:
+```ruby
+  # Example Faraday connection that uses the Instrumentation middleware
+  service = Faraday::Connection.new(url: Smartcar::API_ORIGIN, request: { timeout: Smartcar::DEFAULT_REQUEST_TIMEOUT }) do |c|
+    c.request :instrumentation
+  end
+
+  # Passing the custom service to #get_vehicles
+  Smartcar.get_vehicles(token: token, options: { service: service })
+
+  # Passing the custom service to #get_user
+  Smartcar.get_user(token: token, options: { service: service })
+
+  # Passing the custom service to #get_compatibility
+  Smartcar.get_compatibility(vin: vin, scope: scope, options: { service: service })
+
+  # Passing the custom service into a Smartcar::Vehicle object
+  vehicle = Smartcar::Vehicle.new(token: token, id: id, options: { service: service })
+```
+
 ## Development
 
 To install this gem onto your local machine, run `bundle exec rake install`.

--- a/lib/smartcar.rb
+++ b/lib/smartcar.rb
@@ -31,6 +31,9 @@ module Smartcar
   # Constant for units
   UNITS = [IMPERIAL, METRIC].freeze
 
+  # Number of seconds to wait for responses
+  DEFAULT_REQUEST_TIMEOUT = 310
+
   # Smartcar API version variable - defaulted to 2.0
   @api_version = '2.0'
 
@@ -65,9 +68,10 @@ module Smartcar
     # @option options [String] :client_secret Client Secret that overrides ENV
     # @option options [String] :version API version to use, defaults to what is globally set
     # @option options [Hash] :flags A hash of flag name string as key and a string or boolean value.
-    # @option options [Boolean] :test_mode Wether to use test mode or not.
+    # @option options [Boolean] :test_mode Whether to use test mode or not.
     # @option options [String] :test_mode_compatibility_level this is required argument while using
     # test mode with a real vin. For more information refer to docs.
+    # @option options [Faraday::Connection] :service Optional connection object to be used for requests
     #
     # @return [OpenStruct] And object representing the JSON response mentioned in https://smartcar.com/docs/api#connect-compatibility
     #  and a meta attribute with the relevant items from response headers.
@@ -78,7 +82,8 @@ module Smartcar
       base_object = Base.new(
         {
           version: options[:version] || Smartcar.get_api_version,
-          auth_type: Base::BASIC
+          auth_type: Base::BASIC,
+          service: options[:service]
         }
       )
 
@@ -94,14 +99,18 @@ module Smartcar
     #
     # API Documentation - https://smartcar.com/docs/api#get-user
     # @param token [String] Access token
+    # @param version [String] Optional API version to use, defaults to what is globally set
+    # @param options [Hash] Other optional parameters including overrides
+    # @option options [Faraday::Connection] :service Optional connection object to be used for requests
     #
     # @return [OpenStruct] And object representing the JSON response mentioned in https://smartcar.com/docs/api#get-user
     #  and a meta attribute with the relevant items from response headers.
-    def get_user(token:, version: Smartcar.get_api_version)
+    def get_user(token:, version: Smartcar.get_api_version, options: {})
       base_object = Base.new(
         {
           token: token,
-          version: version
+          version: version,
+          service: options[:service]
         }
       )
       base_object.build_response(*base_object.fetch(path: PATHS[:user]))
@@ -112,14 +121,18 @@ module Smartcar
     # API Documentation - https://smartcar.com/docs/api#get-all-vehicles
     # @param token [String] - Access token
     # @param paging [Hash] - Optional filter parameters (check documentation)
+    # @param version [String] Optional API version to use, defaults to what is globally set
+    # @param options [Hash] Other optional parameters including overrides
+    # @option options [Faraday::Connection] :service Optional connection object to be used for requests
     #
     # @return [OpenStruct] And object representing the JSON response mentioned in https://smartcar.com/docs/api#get-all-vehicles
     #  and a meta attribute with the relevant items from response headers.
-    def get_vehicles(token:, paging: {}, version: Smartcar.get_api_version)
+    def get_vehicles(token:, paging: {}, version: Smartcar.get_api_version, options: {})
       base_object = Base.new(
         {
           token: token,
-          version: version
+          version: version,
+          service: options[:service]
         }
       )
       base_object.build_response(*base_object.fetch(

--- a/lib/smartcar/base.rb
+++ b/lib/smartcar/base.rb
@@ -13,8 +13,6 @@ module Smartcar
     class InvalidParameterValue < StandardError; end
     # Constant for Basic auth type
     BASIC = 'Basic'
-    # Number of seconds to wait for response
-    REQUEST_TIMEOUT = 310
 
     attr_accessor :token, :error, :unit_system, :version, :auth_type
 
@@ -65,7 +63,10 @@ module Smartcar
     #
     # @return [OAuth2::AccessToken] An initialized AccessToken instance that acts as service client
     def service
-      @service ||= Faraday.new(url: ENV['SMARTCAR_API_ORIGIN'] || API_ORIGIN, request: { timeout: REQUEST_TIMEOUT })
+      @service ||= Faraday.new(
+        url: ENV['SMARTCAR_API_ORIGIN'] || API_ORIGIN,
+        request: { timeout: DEFAULT_REQUEST_TIMEOUT }
+      )
     end
   end
 end

--- a/lib/smartcar/vehicle.rb
+++ b/lib/smartcar/vehicle.rb
@@ -11,6 +11,7 @@ module Smartcar
   # @attr [Hash] options
   # @attr unit_system [String] Unit system to represent the data in, defaults to Imperial
   # @attr version [String] API version to be used.
+  # @attr service [Faraday::Connection] An optional connection object to be used for requests.
   class Vehicle < Base
     attr_reader :id
 
@@ -69,12 +70,13 @@ module Smartcar
                                          }, skip: true }
     }.freeze
 
-    def initialize(token:, id:, options: { unit_system: METRIC, version: Smartcar.get_api_version })
+    def initialize(token:, id:, options: {})
       super
       @token = token
       @id = id
-      @unit_system = options[:unit_system]
-      @version = options[:version]
+      @unit_system = options[:unit_system] || METRIC
+      @version = options[:version] || Smartcar.get_api_version
+      @service = options[:service]
 
       raise InvalidParameterValue.new, "Invalid Units provided : #{@unit_system}" unless UNITS.include?(@unit_system)
       raise InvalidParameterValue.new, 'Vehicle ID (id) is a required field' if id.nil?

--- a/spec/smartcar/integration/smartcar_spec.rb
+++ b/spec/smartcar/integration/smartcar_spec.rb
@@ -131,6 +131,65 @@ RSpec.describe Smartcar do
         )
       end
     end
+
+    context 'when a service object is provided' do
+      let(:mock_service) { Faraday.new(url: 'https://custom-api.smartcar.com') }
+
+      it 'should use the provided service object' do
+        scopes = %w[read_odometer read_location]
+        stub_request(:get, 'https://custom-api.smartcar.com/v2.0/compatibility?country=US&scope=read_odometer%20read_location&vin=vin')
+          .with(
+            basic_auth: [ENV['E2E_SMARTCAR_CLIENT_ID'], ENV['E2E_SMARTCAR_CLIENT_SECRET']]
+          )
+          .to_return(
+            {
+              status: 200,
+              headers: { 'content-type' => 'application/json; charset=utf-8' },
+              body:
+              {
+                compatible: true
+              }.to_json
+            }
+          )
+
+        subject.get_compatibility(
+          vin: 'vin',
+          scope: scopes,
+          country: 'US',
+          options: {
+            service: mock_service
+          }
+        )
+      end
+    end
+  end
+
+  describe '.get_user' do
+    context 'when a service object is provided' do
+      let(:mock_service) { Faraday.new(url: 'https://custom-api.smartcar.com') }
+
+      it 'should use the provided service object' do
+        stub_request(:get, 'https://custom-api.smartcar.com/v2.0/user')
+          .with(headers: { 'Authorization' => 'Bearer token' })
+          .to_return(
+            {
+              status: 200,
+              headers: { 'content-type' => 'application/json; charset=utf-8' },
+              body:
+              {
+                user: { id: 'abc12345-6789-1234-abcd-123abc123abc' }
+              }.to_json
+            }
+          )
+
+        subject.get_user(
+          token: 'token',
+          options: {
+            service: mock_service
+          }
+        )
+      end
+    end
   end
 
   describe '.get_vehicles' do
@@ -155,6 +214,34 @@ RSpec.describe Smartcar do
       expect(response.paging.is_a?(OpenStruct)).to be_truthy
       expect(response.paging.offset).to be(0)
       expect(response.paging.count).to be(1)
+    end
+
+    context 'when a service object is provided' do
+      let(:mock_service) { Faraday.new(url: 'https://custom-api.smartcar.com') }
+
+      it 'should use the provided service object' do
+        stub_request(:get, 'https://custom-api.smartcar.com/v2.0/vehicles?limit=1')
+          .with(headers: { 'Authorization' => 'Bearer token' })
+          .to_return(
+            {
+              status: 200,
+              headers: { 'content-type' => 'application/json; charset=utf-8' },
+              body:
+              {
+                vehicles: ['vehicle1'],
+                paging: { count: 1, offset: 0 }
+              }.to_json
+            }
+          )
+
+        subject.get_vehicles(
+          token: 'token',
+          paging: { limit: 1 },
+          options: {
+            service: mock_service
+          }
+        )
+      end
     end
   end
 end

--- a/spec/smartcar/integration/vehicle_spec.rb
+++ b/spec/smartcar/integration/vehicle_spec.rb
@@ -53,6 +53,32 @@ RSpec.describe Smartcar::Vehicle do
         expect(result.pizza).to eq('pasta')
       end
     end
+
+    context 'with a custom service' do
+      let(:mock_service) { Faraday.new(url: 'https://custom-api.smartcar.com') }
+
+      it 'uses the provided service object' do
+        subject = Smartcar::Vehicle.new(
+          token: 'token',
+          id: 'vehicle_id',
+          options: {
+            service: mock_service
+          }
+        )
+
+        stub_request(:get, 'https://custom-api.smartcar.com/v2.0/vehicles/vehicle_id/odometer')
+          .with(headers: { 'Authorization' => 'Bearer token', 'sc-unit-system' => 'metric' })
+          .to_return(
+            {
+              status: 200,
+              body: { pizza: 'pasta' }.to_json
+            }
+          )
+
+        result = subject.odometer
+        expect(result.pizza).to eq('pasta')
+      end
+    end
   end
 
   describe '#batch' do


### PR DESCRIPTION
At [Recurrent](https://www.recurrentauto.com/) we have some more advanced needs when it comes to using this gem, including:
* Ability to customize both open and request timeouts of certain HTTP requests
* Ability to inject custom logging and instrumentation middleware

We currently monkey patch some of that behavior into this gem in our application, but it's quite messy and is making the upgrade from 2.x to 3.x rather cumbersome.

My goal with this PR is to allow users of the gem to provide their own `Faraday::Connection` object to support a wide range of customization needs. Including this functionality (or something similar) would be really helpful by allowing us to remove a lot of monkey patched code, and make it much easier to upgrade to 3.x and beyond.

I'm totally open to feedback on implementation details. I also added some unit and integration specs, but I couldn't get the E2E specs to run locally.

Thanks for the consideration!