### PR TITLE
chore: update url for Compatility API Docs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    smartcar (3.1.0)
+    smartcar (3.1.1)
       oauth2 (~> 1.4)
       recursive-open-struct (~> 1.1.3)
 

--- a/lib/smartcar.rb
+++ b/lib/smartcar.rb
@@ -54,7 +54,7 @@ module Smartcar
 
     # Module method Used to check compatiblity for VIN and scope
     #
-    # API Documentation - https://smartcar.com/docs/api#connect-compatibility
+    # API Documentation - https://smartcar.com/docs/api#compatibility-api
     # @param vin [String] VIN of the vehicle to be checked
     # @param scope [Array of Strings] - array of scopes
     # @param country [String] An optional country code according to

--- a/lib/smartcar.rb
+++ b/lib/smartcar.rb
@@ -69,7 +69,7 @@ module Smartcar
     # @option options [String] :test_mode_compatibility_level this is required argument while using
     # test mode with a real vin. For more information refer to docs.
     #
-    # @return [OpenStruct] And object representing the JSON response mentioned in https://smartcar.com/docs/api#connect-compatibility
+    # @return [OpenStruct] And object representing the JSON response mentioned in https://smartcar.com/docs/api#compatibility-api
     #  and a meta attribute with the relevant items from response headers.
     def get_compatibility(vin:, scope:, country: 'US', options: {})
       raise InvalidParameterValue.new, 'vin is a required field' if vin.nil?

--- a/lib/smartcar.rb
+++ b/lib/smartcar.rb
@@ -54,20 +54,19 @@ module Smartcar
 
     # Module method Used to check compatiblity for VIN and scope
     #
-    # API Documentation - https://smartcar.com/docs/api#compatibility-api
+    # API Documentation - https://smartcar.com/docs/api#compatibility-api. Options Hash
     # @param vin [String] VIN of the vehicle to be checked
     # @param scope [Array of Strings] - array of scopes
     # @param country [String] An optional country code according to
-    # [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
-    # Defaults to US.
-    # @param options [Hash] Other optional parameters including overrides
+    # [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). Defaults to US.
+    # @param options [Hash] Other optional parameters including overrides (only valid for Smartcar API v1.0)
     # @option options [String] :client_id Client ID that overrides ENV
     # @option options [String] :client_secret Client Secret that overrides ENV
     # @option options [String] :version API version to use, defaults to what is globally set
     # @option options [Hash] :flags A hash of flag name string as key and a string or boolean value.
     # @option options [Boolean] :test_mode Wether to use test mode or not.
-    # @option options [String] :test_mode_compatibility_level this is required argument while using
-    # test mode with a real vin. For more information refer to docs.
+    # @option options [String] :test_mode_compatibility_level this is required argument while
+    #    using test mode with a real vin. For more information refer to docs.
     #
     # @return [OpenStruct] And object representing the JSON response mentioned in https://smartcar.com/docs/api#compatibility-api
     #  and a meta attribute with the relevant items from response headers.

--- a/lib/smartcar/version.rb
+++ b/lib/smartcar/version.rb
@@ -2,5 +2,5 @@
 
 module Smartcar
   # Gem current version number
-  VERSION = '3.1.0'
+  VERSION = '3.1.1'
 end


### PR DESCRIPTION
Use #compatibility-api as url fragment instead of (no longer existant) #connect-compatibility