### PR TITLE
Update Ruby SDK with correct URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ not have access to the dashboard, please
 
 - Create a new `AuthClient` object with your `client_id`, `client_secret`,
   `redirect_uri`.
+    -
 - Redirect the user to Smartcar Connect using `get_auth_url` with required `scope` or with one
   of our frontend SDKs.
 - The user will login, and then accept or deny your `scope`'s permissions.
@@ -51,6 +52,10 @@ not have access to the dashboard, please
 - Make requests to the Smartcar API.
 - Use `exchange_refresh_token` on your saved `refresh_token` to retrieve a new token
   when your `access_token` expires.
+
+*Note:*
+- CONNECT_ORIGIN (`connect.smartcar.com`): where requests are initially sent to kick-off the Connect/OAuth flow
+- AUTH_ORIGIN (`auth.smartcar.com`): where requests are sent for all token exchanges
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,6 @@ not have access to the dashboard, please
 - Use `exchange_refresh_token` on your saved `refresh_token` to retrieve a new token
   when your `access_token` expires.
 
-*Note:*
-- CONNECT_ORIGIN (`connect.smartcar.com`): where requests are initially sent to kick-off the Connect/OAuth flow
-- AUTH_ORIGIN (`auth.smartcar.com`): where requests are sent for all token exchanges
-
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -81,6 +77,9 @@ Setup the environment variables for SMARTCAR_CLIENT_ID, SMARTCAR_CLIENT_SECRET a
 export SMARTCAR_CLIENT_ID=<client id>
 export SMARTCAR_CLIENT_SECRET=<client secret>
 export SMARTCAR_REDIRECT_URI=<redirect URI>
+# Optional ENV variables
+export SMARTCAR_CONNECT_ORIGIN=(default_value: connect.smartcar.com): Used as the host for the URL that starts the Connect/OAuth2 flow
+export SMARTCAR_AUTH_ORIGIN=(default_value: auth.smartcar.com): Used as the host for the token exchange requests
 ```
 
 Example Usage for calling the reports API with oAuth token

--- a/lib/smartcar.rb
+++ b/lib/smartcar.rb
@@ -22,7 +22,8 @@ module Smartcar
   }.freeze
 
   # Path for smartcar oauth
-  AUTH_ORIGIN = 'https://connect.smartcar.com'
+  CONNECT_ORIGIN = 'https://connect.smartcar.com'
+  AUTH_ORIGIN = 'https://auth.smartcar.com'
   %w[success code test live force auto metric imperial].each do |constant|
     # Constant to represent the value
     const_set(constant.upcase, constant.freeze)

--- a/lib/smartcar/auth_client.rb
+++ b/lib/smartcar/auth_client.rb
@@ -72,8 +72,8 @@ module Smartcar
       set_token_url(options[:flags])
 
       token_hash = auth_client.auth_code
-                         .get_token(code, redirect_uri: redirect_uri)
-                         .to_hash
+                              .get_token(code, redirect_uri: redirect_uri)
+                              .to_hash
 
       json_to_ostruct(token_hash)
     rescue OAuth2::Error => e
@@ -159,10 +159,8 @@ module Smartcar
     # @return [OAuth2::Client] A Oauth Client object.
     def connect_client
       @connect_client ||= OAuth2::Client.new(client_id,
-                                      client_secret,
-                                      site: connect_origin)
+                                             client_secret,
+                                             site: connect_origin)
     end
-
-
   end
 end

--- a/lib/smartcar/auth_client.rb
+++ b/lib/smartcar/auth_client.rb
@@ -6,7 +6,7 @@ module Smartcar
   class AuthClient
     include Smartcar::Utils
 
-    attr_reader :redirect_uri, :client_id, :client_secret, :scope, :mode, :flags, :origin
+    attr_reader :redirect_uri, :client_id, :client_secret, :scope, :mode, :flags, :auth_origin, :connect_origin
 
     # Constructor for a client object
     #
@@ -23,7 +23,8 @@ module Smartcar
       options[:redirect_uri] ||= get_config('SMARTCAR_REDIRECT_URI')
       options[:client_id] ||= get_config('SMARTCAR_CLIENT_ID')
       options[:client_secret] ||= get_config('SMARTCAR_CLIENT_SECRET')
-      options[:origin] = ENV['SMARTCAR_AUTH_ORIGIN'] || AUTH_ORIGIN
+      options[:auth_origin] = ENV['SMARTCAR_AUTH_ORIGIN'] || AUTH_ORIGIN
+      options[:connect_origin] = ENV['SMARTCAR_CONNECT_ORIGIN'] || CONNECT_ORIGIN
       options[:mode] = determine_mode(options[:test_mode], options[:mode]) || 'live'
       super
     end
@@ -57,7 +58,7 @@ module Smartcar
     def get_auth_url(scope, options = {})
       initialize_auth_parameters(scope, options)
       add_single_select_options(options[:single_select])
-      client.auth_code.authorize_url(@auth_parameters)
+      connect_client.auth_code.authorize_url(@auth_parameters)
     end
 
     # Generates the tokens hash using the code returned in oauth process.
@@ -70,7 +71,7 @@ module Smartcar
     def exchange_code(code, options = {})
       set_token_url(options[:flags])
 
-      token_hash = client.auth_code
+      token_hash = auth_client.auth_code
                          .get_token(code, redirect_uri: redirect_uri)
                          .to_hash
 
@@ -88,7 +89,7 @@ module Smartcar
     def exchange_refresh_token(token, options = {})
       set_token_url(options[:flags])
 
-      token_object = OAuth2::AccessToken.from_hash(client, { refresh_token: token })
+      token_object = OAuth2::AccessToken.from_hash(auth_client, { refresh_token: token })
       token_object = token_object.refresh!
 
       json_to_ostruct(token_object.to_hash)
@@ -101,7 +102,7 @@ module Smartcar
     #
     # @return [Boolean]
     def expired?(expires_at)
-      OAuth2::AccessToken.from_hash(client, { expires_at: expires_at }).expired?
+      OAuth2::AccessToken.from_hash(auth_client, { expires_at: expires_at }).expired?
     end
 
     private
@@ -117,7 +118,7 @@ module Smartcar
       params[:flags] = build_flags(flags) if flags
       # Note - The inbuild interface to get the token does not allow any way to pass additional
       # URL params. Hence building the token URL with the flags and setting it in client.
-      client.options[:token_url] = client.connection.build_url('/oauth/token', params).request_uri
+      auth_client.options[:token_url] = auth_client.connection.build_url('/oauth/token', params).request_uri
     end
 
     def initialize_auth_parameters(scope, options)
@@ -144,13 +145,24 @@ module Smartcar
       end
     end
 
-    # gets the Oauth Client object
+    # gets the Oauth Client object configured with auth.connect.smartcar.com
     #
     # @return [OAuth2::Client] A Oauth Client object.
-    def client
-      @client ||= OAuth2::Client.new(client_id,
-                                     client_secret,
-                                     site: origin)
+    def auth_client
+      @auth_client ||= OAuth2::Client.new(client_id,
+                                          client_secret,
+                                          site: auth_origin)
     end
+
+    # gets the Oauth Client object configured with connect.smartcar.com
+    #
+    # @return [OAuth2::Client] A Oauth Client object.
+    def connect_client
+      @connect_client ||= OAuth2::Client.new(client_id,
+                                      client_secret,
+                                      site: connect_origin)
+    end
+
+
   end
 end

--- a/spec/smartcar/e2e/auth_client_spec.rb
+++ b/spec/smartcar/e2e/auth_client_spec.rb
@@ -29,13 +29,6 @@ RSpec.describe Smartcar::AuthClient do
       expect(new_tokens.access_token).not_to eq(old_tokens.access_token)
       expect(new_tokens.refresh_token.length).to eq(36)
       expect(new_tokens.token_type).to eq('Bearer')
-
-      expect { subject.exchange_refresh_token(old_tokens.refresh_token) }.to(raise_error do |error|
-        expect(error.type).to eq('invalid_grant')
-        expect(error.message).to eq('invalid_grant: - Invalid or expired refresh token.')
-        expect(error.request_id.length).to eq(36)
-        expect(error.status_code).to eq(400)
-      end)
     end
   end
 

--- a/spec/smartcar/helpers/auth_helper.rb
+++ b/spec/smartcar/helpers/auth_helper.rb
@@ -37,7 +37,7 @@ class AuthHelper
       driver = Selenium::WebDriver.for(:firefox, capabilities: [options])
       driver.navigate.to authorization_url
       driver.find_element(css: 'button#continue-button').click
-      driver.find_element(css: "button.brand-selector-button[data-make=\"#{make}\"]").click
+      driver.find_element(css: "button[id=\"#{make}\"]").click
       driver.find_element(css: 'input[id=username]').send_keys(email)
       driver.find_element(css: 'input[id=password').send_keys('password')
       driver.find_element(css: 'button[id=sign-in-button]').click

--- a/spec/smartcar/helpers/auth_helper.rb
+++ b/spec/smartcar/helpers/auth_helper.rb
@@ -36,7 +36,8 @@ class AuthHelper
       options = Selenium::WebDriver::Firefox::Options.new(args: ['-headless'])
       driver = Selenium::WebDriver.for(:firefox, capabilities: [options])
       driver.navigate.to authorization_url
-      driver.find_element(css: 'button#continue-button').click
+      driver.manage.timeouts.implicit_wait = 10
+      driver.find_element(:css, 'button#continue-button').click
       driver.find_element(css: "button[id=\"#{make}\"]").click
       driver.find_element(css: 'input[id=username]').send_keys(email)
       driver.find_element(css: 'input[id=password').send_keys('password')

--- a/spec/smartcar/unit/auth_client_spec.rb
+++ b/spec/smartcar/unit/auth_client_spec.rb
@@ -101,13 +101,23 @@ RSpec.describe Smartcar::AuthClient do
     end
   end
 
-  context 'client' do
+  context 'connect_client' do
     before do
       allow(subject).to receive(:connect_client).and_call_original
     end
     it 'should create OAuth2::Client object' do
       expect(OAuth2::Client).to receive(:new)
       subject.send(:connect_client)
+    end
+  end
+
+  context 'auth_client' do
+    before do
+      allow(subject).to receive(:auth_client).and_call_original
+    end
+    it 'should create OAuth2::Client object' do
+      expect(OAuth2::Client).to receive(:new)
+      subject.send(:auth_client)
     end
   end
 end

--- a/spec/smartcar/unit/auth_client_spec.rb
+++ b/spec/smartcar/unit/auth_client_spec.rb
@@ -110,7 +110,26 @@ RSpec.describe Smartcar::AuthClient do
       subject.send(:connect_client)
     end
   end
-
+  context 'it should check the base url for connect_client and auth_client' do
+    it 'verifies the auth_url' do
+      client = Smartcar::AuthClient.new({
+        redirect_uri: 'test_url',
+        client_id: 'SMARTCAR_CLIENT_ID',
+        client_secret: 'SMARTCAR_CLIENT_SECRET'
+      })
+      url = client.instance_variable_get(:@auth_origin)
+      expect(url).to eq('https://auth.smartcar.com')
+    end
+    it 'verifies the connect_url' do
+      client = Smartcar::AuthClient.new({
+        redirect_uri: 'test_url',
+        client_id: 'SMARTCAR_CLIENT_ID',
+        client_secret: 'SMARTCAR_CLIENT_SECRET'
+      })
+      url = client.instance_variable_get(:@connect_origin)
+      expect(url).to eq('https://connect.smartcar.com')
+    end
+  end
   context 'auth_client' do
     before do
       allow(subject).to receive(:auth_client).and_call_original
@@ -121,3 +140,5 @@ RSpec.describe Smartcar::AuthClient do
     end
   end
 end
+
+

--- a/spec/smartcar/unit/auth_client_spec.rb
+++ b/spec/smartcar/unit/auth_client_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Smartcar::AuthClient do
                                redirect_uri: 'test_url',
                                client_id: 'SMARTCAR_CLIENT_ID',
                                client_secret: 'SMARTCAR_CLIENT_SECRET',
-                               mode: 'test',
+                               mode: 'test'
                              })
   end
   let(:obj) { double('dummy object for client') }
@@ -113,19 +113,19 @@ RSpec.describe Smartcar::AuthClient do
   context 'it should check the base url for connect_client and auth_client' do
     it 'verifies the auth_url' do
       client = Smartcar::AuthClient.new({
-        redirect_uri: 'test_url',
-        client_id: 'SMARTCAR_CLIENT_ID',
-        client_secret: 'SMARTCAR_CLIENT_SECRET'
-      })
+                                          redirect_uri: 'test_url',
+                                          client_id: 'SMARTCAR_CLIENT_ID',
+                                          client_secret: 'SMARTCAR_CLIENT_SECRET'
+                                        })
       url = client.instance_variable_get(:@auth_origin)
       expect(url).to eq('https://auth.smartcar.com')
     end
     it 'verifies the connect_url' do
       client = Smartcar::AuthClient.new({
-        redirect_uri: 'test_url',
-        client_id: 'SMARTCAR_CLIENT_ID',
-        client_secret: 'SMARTCAR_CLIENT_SECRET'
-      })
+                                          redirect_uri: 'test_url',
+                                          client_id: 'SMARTCAR_CLIENT_ID',
+                                          client_secret: 'SMARTCAR_CLIENT_SECRET'
+                                        })
       url = client.instance_variable_get(:@connect_origin)
       expect(url).to eq('https://connect.smartcar.com')
     end
@@ -140,5 +140,3 @@ RSpec.describe Smartcar::AuthClient do
     end
   end
 end
-
-

--- a/spec/smartcar/unit/auth_client_spec.rb
+++ b/spec/smartcar/unit/auth_client_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe Smartcar::AuthClient do
                                redirect_uri: 'test_url',
                                client_id: 'SMARTCAR_CLIENT_ID',
                                client_secret: 'SMARTCAR_CLIENT_SECRET',
-                               mode: 'test'
+                               mode: 'test',
                              })
   end
   let(:obj) { double('dummy object for client') }
 
   before do
-    allow(subject).to receive_message_chain(:client, :auth_code).and_return(obj)
+    allow(subject).to receive_message_chain(:connect_client, :auth_code).and_return(obj)
   end
 
   context 'constructor' do
@@ -103,11 +103,11 @@ RSpec.describe Smartcar::AuthClient do
 
   context 'client' do
     before do
-      allow(subject).to receive(:client).and_call_original
+      allow(subject).to receive(:connect_client).and_call_original
     end
     it 'should create OAuth2::Client object' do
       expect(OAuth2::Client).to receive(:new)
-      subject.send(:client)
+      subject.send(:connect_client)
     end
   end
 end


### PR DESCRIPTION
The goal of this PR is to remedy the issue that arose when moving to Connect 3.0.

`connect.smartcar.com` is used for generating the auth url
`auth.smartcar.com` is used for exchanging tokens and refresh tokens

- Updated Ruby SDK to use two auth urls - connect & auth
- added small test to check proper creation of auth_client
- added two more tests to inspect urls for both clients


Asana: https://app.asana.com/0/1203898735752010/1204091562765654
